### PR TITLE
未読リプライ一覧表示機能の開発

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -8,6 +8,11 @@ class UsersController extends Controller
 {
     public function notifications()
     {
+        // 未読リプライを既読にする
+        auth()->user()->unreadNotifications->markAsRead();
 
+        return view('users.notifications', [
+           'notifications' => auth()->user()->notifications()->paginate(5),
+        ]);
     }
 }

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -17,7 +17,7 @@
     <link href="{{ asset('css/app.css') }}" rel="stylesheet">
 
     <style>
-        .btn-info {
+        .btn-info, .badge-info{
             color: #fff;
         }
     </style>
@@ -40,9 +40,10 @@
                     <ul class="navbar-nav mr-auto">
                         @auth
                             <li class="nav-item">
-                                <a href="" class="nav-link">
+                                <a href="{{ route('users.notifications') }}" class="nav-link">
                                     <span class="badge badge-info">
                                         {{ auth()->user()->unreadNotifications->count() }}
+                                        Unread Notifications
                                     </span>
                                 </a>
                             </li>

--- a/resources/views/users/notifications.blade.php
+++ b/resources/views/users/notifications.blade.php
@@ -1,0 +1,20 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="card">
+        <div class="card-header">Notifications</div>
+        <div class="card-body">
+            <ul class="list-group">
+                @foreach($notifications as $notification)
+                    <li class="list-group-item">
+                        @if($notification->type === 'App\Notifications\NewReplyAdded')
+                            <span>A New Reply Was Added to Your Discussion.</span>
+                            <span style="font-weight: bold;">{{ $notification->data['discussion']['title'] }}</span>
+                            <a href="{{ route('discussions.show', $notification->data['discussion']['slug']) }}" class="btn btn-sm btn-info float-right">View Discussion</a>
+                        @endif
+                    </li>
+                @endforeach
+            </ul>
+        </div>
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,5 +27,5 @@ Route::get('/home', 'HomeController@index')->name('home');
 Route::resource('discussions', 'DiscussionsController');
 Route::resource('discussions/{discussion}/replies', 'RepliesController');
 
-Route::get('users/notifications', [UsersController::class, 'notifications']);
+Route::get('users/notifications', [UsersController::class, 'notifications'])->name('users.notifications');
 Route::post('discussions/{discussion}/replies/{reply}/mark-as-best-reply', 'DiscussionsController@reply')->name('discussions.best-reply');


### PR DESCRIPTION
## 概要・要望
未読リプライを一覧表示するページを作成したい。
また、未読リプライ一覧ページから詳細ボタンを押下したら、該当のリプライに画面遷移するようにしたい。

## TODO
- [x] 未読リプライ取得のロジック追加
- [x] 未読リプライ一覧ページのViewの作成
- [x] 未読リプライを既読にするロジックの追加

## PRマージまでのチェックリスト
- [x] merge準備完了
  - [x] この項目以外のチェックボックス全てにチェックが入っている
  - [x] conflictが発生していない
  - [x] 最新の親ブランチでrebaseが完了している
  - [x] mergeしても良いタイミングである
