### PR TITLE
キューを使用してメール通知を遅延処理させる

### DIFF
--- a/app/Notifications/NewReplyAdded.php
+++ b/app/Notifications/NewReplyAdded.php
@@ -8,7 +8,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class NewReplyAdded extends Notification
+class NewReplyAdded extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/app/Notifications/ReplyMarkedAsBestReply.php
+++ b/app/Notifications/ReplyMarkedAsBestReply.php
@@ -8,7 +8,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class ReplyMarkedAsBestReply extends Notification
+class ReplyMarkedAsBestReply extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/database/migrations/2020_03_11_115343_create_jobs_table.php
+++ b/database/migrations/2020_03_11_115343_create_jobs_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateJobsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('jobs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('queue')->index();
+            $table->longText('payload');
+            $table->unsignedTinyInteger('attempts');
+            $table->unsignedInteger('reserved_at')->nullable();
+            $table->unsignedInteger('available_at');
+            $table->unsignedInteger('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('jobs');
+    }
+}


### PR DESCRIPTION
## 概要・要望
以下二つの通知処理をsyncしていることにより、ユーザーがPOSTした際のレスポンスが遅くなっている。そのためメール通知処理を遅延処理化して、ユーザーがPOSTした際のレスポンスを早めたい。
対象の通知処理
・リプライ通知処理
・ベストアンサー通知

## TODO
- [x] jobテーブルを作成する
- [x] メール通知を遅延処理化する

## PRマージまでのチェックリスト
- [x] merge準備完了
  - [x] この項目以外のチェックボックス全てにチェックが入っている
  - [x] conflictが発生していない
  - [x] 最新の親ブランチでrebaseが完了している
  - [x] mergeしても良いタイミングである
