### PR TITLE
サイドメニューのディスカッション名にリンクをつける

### DIFF
--- a/app/Discussion.php
+++ b/app/Discussion.php
@@ -39,4 +39,17 @@ class Discussion extends Model
 
         $reply->owner->notify(new ReplyMarkedAsBestReply($reply->discussion));
     }
+
+    public function scopeFilterByChannels($builder)
+    {
+        if (request()->query('channel')) {
+            $channel = Channel::where('slug', request()->query('channel'))->first();
+            if ($channel) {
+                return $builder->where('channel_id', $channel->id);
+            }
+            return $builder;
+        }
+
+        return $builder;
+    }
 }

--- a/app/Http/Controllers/DiscussionsController.php
+++ b/app/Http/Controllers/DiscussionsController.php
@@ -22,7 +22,7 @@ class DiscussionsController extends Controller
     public function index()
     {
         return view('discussions.index', [
-            'discussions' => Discussion::paginate(5)
+            'discussions' => Discussion::filterByChannels()->paginate(5)
         ]);
     }
 

--- a/resources/views/discussions/index.blade.php
+++ b/resources/views/discussions/index.blade.php
@@ -13,6 +13,6 @@
 </div>
 @endforeach
 
-{{ $discussions->links() }}
+{{ $discussions->appends(['channel' => request()->query('channel')])->links() }}
 
 @endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -105,7 +105,9 @@
                                 <ul class="list-group">
                                     @foreach($channels as $channel)
                                         <li class="list-group-item">
-                                            {{ $channel->name }}
+                                            <a href="{{ route('discussions.index') }}?channel={{ $channel->slug }}">
+                                                {{ $channel->name }}
+                                            </a>
                                         </li>
                                     @endforeach
                                 </ul>


### PR DESCRIPTION
## 概要・要望
サイドメニューのディスカッション名を押下したら、同一のディスカッションが表示されるようにしたい。

## TODO
- [x] ディスカッション名にリンクをつける
- [x] ディスカッション名を押下した際に絞り込みを行うクエリを定義する

## PRマージまでのチェックリスト
- [x] merge準備完了
  - [x] この項目以外のチェックボックス全てにチェックが入っている
  - [x] conflictが発生していない
  - [x] 最新の親ブランチでrebaseが完了している
  - [x] mergeしても良いタイミングである
