### PR TITLE
自分の投稿には通知メールが飛ばないようにする

### DIFF
--- a/app/Discussion.php
+++ b/app/Discussion.php
@@ -37,6 +37,10 @@ class Discussion extends Model
             'reply_id' => $reply->id,
         ]);
 
+        if ($reply->owner->id === $this->author->id) {
+            return;
+        }
+
         $reply->owner->notify(new ReplyMarkedAsBestReply($reply->discussion));
     }
 

--- a/app/Http/Controllers/RepliesController.php
+++ b/app/Http/Controllers/RepliesController.php
@@ -43,7 +43,9 @@ class RepliesController extends Controller
             'discussion_id' => $discussion->id,
         ]);
 
-        $discussion->author->notify(new NewReplyAdded($discussion));
+        if ($discussion->author->id != auth()->user()->id) {
+            $discussion->author->notify(new NewReplyAdded($discussion));
+        }
 
         session()->flash('success', 'Reply Added.');
 


### PR DESCRIPTION
## 概
以下2つの条件にてバグが存在するので修正したい
・自分のディスカッションにリプライした際に通知が飛んでしまう
・自分のリプライをベストアンサーに選んだ際に通知が飛んでしまう

## TODO
- [x] deliscussionsコントローラー内に処理を追加する


## PRマージまでのチェックリスト
- [x] merge準備完了
  - [x] この項目以外のチェックボックス全てにチェックが入っている
  - [x] conflictが発生していない
  - [x] 最新の親ブランチでrebaseが完了している
  - [x] mergeしても良いタイミングである
