### PR TITLE
未ログイン時にいいねしたらエラーになる事象の修正

### DIFF
--- a/app/Http/Controllers/RepliesController.php
+++ b/app/Http/Controllers/RepliesController.php
@@ -12,6 +12,11 @@ use Illuminate\Support\Facades\Auth;
 
 class RepliesController extends Controller
 {
+    public function __construct()
+    {
+        $this->middleware(['auth', 'verified'])->only(['like', 'unlike']);
+    }
+
     /**
      * Display a listing of the resource.
      *


### PR DESCRIPTION
## 概要
未ログイン時にいいねしたらエラーになる事象の修正

## TODO
- [x] コントローラー内にコンストラクターにログイン時のみに有効にする処理を追加する

## PRマージまでのチェックリスト
- [x] merge準備完了
  - [x] この項目以外のチェックボックス全てにチェックが入っている
  - [x] conflictが発生していない
  - [x] 最新の親ブランチでrebaseが完了している
  - [x] mergeしても良いタイミングである
