### PR TITLE
#44 ディスカッションのタイトルを日本語に設定したらslugがnullになる

### DIFF
--- a/app/Http/Controllers/DiscussionsController.php
+++ b/app/Http/Controllers/DiscussionsController.php
@@ -44,12 +44,19 @@ class DiscussionsController extends Controller
      */
     public function store(CreateDiscussionRequest $request)
     {
-        auth()->user()->discussion()->create([
+        $discussion = auth()->user()->discussion()->create([
             'title' => $request->title,
             'slug' => str_slug($request->title),
             'content' => $request['content'],
             'channel_id' => $request->channel
         ]);
+
+        // slugがnullの場合はdiscussion-XXを代わりに代入する(XXがdiscussionのid)
+        if (empty($discussion->slug)) {
+            $discussionId = $discussion->id;
+            $discussion->slug = 'discussion-' . $discussionId;
+            $discussion->save();
+        }
 
         session()->flash('success', 'Discussion posted.');
 


### PR DESCRIPTION
## 概要
#44 ディスカッションのタイトルを日本語に設定したらslugがnullになる

## TODO
- [x] slugがnullの場合は代わりの値を入れる

## PRマージまでのチェックリスト
- [x] merge準備完了
  - [x] この項目以外のチェックボックス全てにチェックが入っている
  - [x] conflictが発生していない
  - [x] 最新の親ブランチでrebaseが完了している
  - [x] mergeしても良いタイミングである
