### PR TITLE
#46 ディスカッション一覧ページで経過時間が表示されてないバグの修正

### DIFF
--- a/resources/views/discussions/index.blade.php
+++ b/resources/views/discussions/index.blade.php
@@ -8,6 +8,11 @@
     <div class="card-body">
         <div class="text-center">
             <strong>{!! $discussion->title !!}</strong>
+
+        </div>
+        <hr>
+        <div class="text-right">
+            <span>{{ $discussion->created_at->diffForHumans() }}</span>
         </div>
     </div>
     <div class="card-footer d-flex justify-content-between">


### PR DESCRIPTION
## 概要
#46 ディスカッション一覧ページで経過時間が表示されてないバグの修正

## TODO
- [x] Viewページの修正

## PRマージまでのチェックリスト
- [x] merge準備完了
  - [x] この項目以外のチェックボックス全てにチェックが入っている
  - [x] conflictが発生していない
  - [x] 最新の親ブランチでrebaseが完了している
  - [x] mergeしても良いタイミングである
